### PR TITLE
Add concurrency key

### DIFF
--- a/.github/workflows/statusfy.yml
+++ b/.github/workflows/statusfy.yml
@@ -3,6 +3,8 @@ on:
   issue_comment:
   issues:
     types: [opened, edited, closed, reopened]
+    
+concurrency: build
 
 jobs:
   build:


### PR DESCRIPTION
This key prevents the workflow from conflicting if several issues are created at the same time.